### PR TITLE
Component fix

### DIFF
--- a/component.json
+++ b/component.json
@@ -8,7 +8,8 @@
   ],
   "dependencies": {
     "noflo/noflo": "*",
-    "component/underscore": "*"
+    "component/underscore": "*",
+    "djdeath/owl-deepcopy": "*"
   },
   "scripts": [
     "components/PacketsToObject.coffee",


### PR DESCRIPTION
The component package of noflo-adapters is a bit broken at the moment.
It's missing a couple of dependencies : underscore and owl-deepcopy.
owl-deepcopy not having a component package right now, I created it on my account and also sent a pull request (if accepted I'll change the dep later).

There is also the issue of .fbp files not included in the browser version of noflo-adapters. Not sure whether I'm missing something here or if it's an actually issue...
